### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -3,20 +3,20 @@
 #######################################
 
 #######################################
-# Instance			   		(KEYWORD1)
+# Instance	(KEYWORD1)
 #######################################
 
 #######################################
-# Methods and Functions		(KEYWORD2)
+# Methods and Functions	(KEYWORD2)
 #######################################
 
-begin KEYWORD2
-poll  KEYWORD2
-getLUX  KEYWORD2
-getUVA  KEYWORD2
-getUVB  KEYWORD2
-getUVIndex  KEYWORD2
+begin	KEYWORD2
+poll	KEYWORD2
+getLUX	KEYWORD2
+getUVA	KEYWORD2
+getUVB	KEYWORD2
+getUVIndex	KEYWORD2
 
 #######################################
-# Constants 		   		(LITERAL1)
+# Constants	(LITERAL1)
 #######################################


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords